### PR TITLE
Add golangci-lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,45 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: ${{ github.ref_name }}-lint
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Go Lint
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Golang Environment
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: Lint Go
+        uses: golangci/golangci-lint-action@v6
+
+  actionlint:
+    name: Actionlint
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Lint Actions
+        uses: reviewdog/action-actionlint@v1
+        with:
+          actionlint_flags: -shellcheck ""

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,89 @@
+linters-settings:
+  misspell:
+    locale: US
+  revive:
+    ignore-generated-header: true
+    rules:
+      - name: blank-imports
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: dot-imports
+      - name: empty-block
+      - name: error-naming
+      - name: error-return
+      - name: error-strings
+      - name: errorf
+      - name: exported
+      - name: increment-decrement
+      - name: indent-error-flow
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: redefines-builtin-id
+      - name: superfluous-else
+      - name: time-naming
+      - name: unexported-return
+      - name: unreachable-code
+      - name: var-declaration
+      - name: var-naming
+  govet:
+    enable-all: true
+linters:
+  enable:
+    - asasalint
+    - asciicheck
+    - bidichk
+    - contextcheck
+    - copyloopvar
+    - dupword
+    - durationcheck
+    - errcheck
+    - errchkjson
+    - errname
+    - errorlint
+    - fatcontext
+    - forcetypeassert
+    - gocheckcompilerdirectives
+    - gochecksumtype
+    - gocritic
+    - godot
+    - gofmt
+    - gofumpt
+    - goimports
+    - gosec
+    - gosimple
+    - gosmopolitan
+    - govet
+    - ineffassign
+    - intrange
+    - makezero
+    - misspell
+    - musttag
+    - nilerr
+    - noctx
+    - nolintlint
+    - perfsprint
+    - prealloc
+    - predeclared
+    - reassign
+    - revive
+    - staticcheck
+    - stylecheck
+    - tagalign
+    - thelper
+    - tparallel
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - usestdlibvars
+    - usetesting
+    - wastedassign
+    - whitespace
+    # - wrapcheck
+  disable-all: true
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+run:
+  timeout: 5m

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ between the producers and the consumers.
         )
         defer sp.Finish()
 
-	// Update the context with the span for the subsequent reference.
+        // Update the context with the span for the subsequent reference.
         ctx = opentracing.ContextWithSpan(ctx, sp)
 
         // Actual message processing.

--- a/amqptracer/propagation.go
+++ b/amqptracer/propagation.go
@@ -4,19 +4,18 @@ package amqptracer
 //
 // Example usage for server side:
 //
-//     carrier := amqpHeadersCarrier(amqp.Table)
-//     clientContext, err := tracer.Extract(
-//         opentracing.TextMap,
-//         carrier)
+//	carrier := amqpHeadersCarrier(amqp.Table)
+//	clientContext, err := tracer.Extract(
+//	    opentracing.TextMap,
+//	    carrier)
 //
 // Example usage for client side:
 //
-//     carrier := amqpHeadersCarrier(amqp.Table)
-//     err := tracer.Inject(
-//         span.Context(),
-//         opentracing.TextMap,
-//         carrier)
-//
+//	carrier := amqpHeadersCarrier(amqp.Table)
+//	err := tracer.Inject(
+//	    span.Context(),
+//	    opentracing.TextMap,
+//	    carrier)
 type amqpHeadersCarrier map[string]interface{}
 
 // ForeachKey conforms to the TextMapReader interface.

--- a/amqptracer/propagation_test.go
+++ b/amqptracer/propagation_test.go
@@ -13,7 +13,12 @@ func TestAMQPHeaderInject(t *testing.T) {
 	h["opname"] = "AlsoNotOT"
 	tracer := testTracer{}
 	span := tracer.StartSpan("someSpan")
-	fakeID := span.Context().(testSpanContext).FakeID
+
+	spanCtx, ok := span.Context().(testSpanContext)
+	if !ok {
+		t.Fatalf("Expected span.Context() to be of type testSpanContext")
+	}
+	fakeID := spanCtx.FakeID
 
 	// Use amqpHeadersCarrier to wrap around `h`.
 	carrier := amqpHeadersCarrier(h)
@@ -45,7 +50,11 @@ func TestAMQPHeaderExtract(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if spanContext.(testSpanContext).FakeID != 42 {
+	testContext, ok := spanContext.(testSpanContext)
+	if !ok {
+		t.Fatalf("Expected spanContext to be of type testSpanContext")
+	}
+	if testContext.FakeID != 42 {
 		t.Errorf("Failed to read testprefix-fakeid correctly")
 	}
 }

--- a/amqptracer/tracer_test.go
+++ b/amqptracer/tracer_test.go
@@ -13,7 +13,12 @@ func TestInject(t *testing.T) {
 	h["opname"] = "AlsoNotOT"
 	tracer := testTracer{}
 	sp := tracer.StartSpan("someSpan")
-	fakeID := sp.Context().(testSpanContext).FakeID
+
+	spanCtx, ok := sp.Context().(testSpanContext)
+	if !ok {
+		t.Fatalf("Expected sp.Context() to be of type testSpanContext")
+	}
+	fakeID := spanCtx.FakeID
 
 	// Inject the tracing context to the AMQP header.
 	if err := Inject(sp, h); err != nil {
@@ -44,7 +49,12 @@ func TestExtract(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ctx.(testSpanContext).FakeID != 42 {
+
+	testCtx, ok := ctx.(testSpanContext)
+	if !ok {
+		t.Fatalf("Expected ctx to be of type testSpanContext")
+	}
+	if testCtx.FakeID != 42 {
 		t.Errorf("Failed to read testprefix-fakeid correctly")
 	}
 }

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>opentracing-contrib/common",
-    "schedule:daily"
+    "schedule:weekly"
   ]
 }


### PR DESCRIPTION
This pull request includes several changes to add a linting workflow, improve test reliability, and update the Renovate configuration. The most important changes include the addition of a GitHub Actions workflow for linting, configuration of `golangci-lint`, enhancements to test robustness, and an update to the Renovate schedule.

### Linting Workflow:
* [`.github/workflows/lint.yml`](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2R1-R45): Added a GitHub Actions workflow to run Go linting and action linting on push and pull request events to the master branch.

### Lint Configuration:
* [`.golangci.yml`](diffhunk://#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9R1-R90): Configured `golangci-lint` with specific linter settings and enabled a comprehensive list of linters to ensure code quality.

### Test Improvements:
* `amqptracer/propagation_test.go`, `amqptracer/tracer_test.go`: Added `t.Parallel()` to enable parallel execution of tests and added type assertion checks to improve test reliability. [[1]](diffhunk://#diff-152d5125999d60995e177170d8f76305155542e7114a17a3623640f89bde45b3R11-R22) [[2]](diffhunk://#diff-152d5125999d60995e177170d8f76305155542e7114a17a3623640f89bde45b3R41) [[3]](diffhunk://#diff-152d5125999d60995e177170d8f76305155542e7114a17a3623640f89bde45b3L48-R59) [[4]](diffhunk://#diff-7a4fa8b802b994de0cdbf848c0b2946e7911c0a5deb849e6759e508f4c23b29dR11-R22) [[5]](diffhunk://#diff-7a4fa8b802b994de0cdbf848c0b2946e7911c0a5deb849e6759e508f4c23b29dR40) [[6]](diffhunk://#diff-7a4fa8b802b994de0cdbf848c0b2946e7911c0a5deb849e6759e508f4c23b29dL47-R59)
* [`amqptracer/testtracer_test.go`](diffhunk://#diff-27216f31183f87ef61b58e394b559abf307e9a06ff74008142b083d9451f7d73L33-R36): Added type assertion checks and error handling to ensure robustness in the test tracer implementation. [[1]](diffhunk://#diff-27216f31183f87ef61b58e394b559abf307e9a06ff74008142b083d9451f7d73L33-R36) [[2]](diffhunk://#diff-27216f31183f87ef61b58e394b559abf307e9a06ff74008142b083d9451f7d73L66) [[3]](diffhunk://#diff-27216f31183f87ef61b58e394b559abf307e9a06ff74008142b083d9451f7d73L93-R94) [[4]](diffhunk://#diff-27216f31183f87ef61b58e394b559abf307e9a06ff74008142b083d9451f7d73L109-R140)

### Renovate Configuration:
* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L5-R5): Updated the Renovate schedule from daily to weekly to reduce the frequency of dependency update checks.